### PR TITLE
Added OpenFOAM 9 and 10 compatibility

### DIFF
--- a/libs/coupleElmer/Elmer.C
+++ b/libs/coupleElmer/Elmer.C
@@ -35,7 +35,9 @@ Web:       http://eof-library.com
 #include <iostream>
 #include <fstream>
 #include "interpolation.H"
+#if (FOAM_MAJOR_VERSION == v1812 || FOAM_MAJOR_VERSION < 10)
 #include "dynamicFvMesh.H"
+#endif
 
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
@@ -531,6 +533,8 @@ void Foam::Elmer<meshT>::MPI_Test_Sleep(MPI_Request& req)
 
 // explicit instantiations
 template class Elmer<fvMesh>;
+#if (FOAM_MAJOR_VERSION == v1812 || FOAM_MAJOR_VERSION < 10)
 template class Elmer<dynamicFvMesh>;
+#endif
 
 // ************************************************************************* //

--- a/libs/coupleElmer/Make/options
+++ b/libs/coupleElmer/Make/options
@@ -7,6 +7,9 @@ ifeq ($(FOAM_MAJOR_VERSION),v1812)
     $(info ************  OF version v1812 ************)
     EOF_LIBS = -L$(FOAM_USER_LIBBIN) -lPstream
     EOF_INC = -I../commSplit/lnInclude
+    DYN_INC = -I$(LIB_SRC)/dynamicFvMesh/lnInclude 
+    DYN_LIBS = -ldynamicFvMesh
+    FVOPT_LIBS = -lfvOptions
 else
     ifeq ($(shell test $(FOAM_MAJOR_VERSION) -lt 6; echo $$?),0)
         $(info ************  OF version <6 ************)
@@ -16,11 +19,20 @@ else
         $(info ************  OF version $(FOAM_MAJOR_VERSION) ************)
         EOF_INC = -I$(LIB_SRC)/Pstream/mpi/lnInclude
     endif
+    ifeq ($(shell test $(FOAM_MAJOR_VERSION) -lt 9; echo $$?),0)
+        $(info ************  OF version <9 ************)
+        FVOPT_LIBS = -lfvOptions
+    endif
+    ifeq ($(shell test $(FOAM_MAJOR_VERSION) -lt 10; echo $$?),0)
+        $(info ************  OF version <10 ************)
+        DYN_INC = -I$(LIB_SRC)/dynamicFvMesh/lnInclude
+        DYN_LIBS = -ldynamicFvMesh
+    endif
 endif
 
 EXE_INC  = \
     -I$(LIB_SRC)/finiteVolume/lnInclude \
-    -I$(LIB_SRC)/dynamicFvMesh/lnInclude \
+    $(DYN_INC) \
     -I$(LIB_SRC)/meshTools/lnInclude \
     $(PFLAGS) $(PINC) -std=gnu++0x \
     -DFOAM_MAJOR_VERSION=$(FOAM_MAJOR_VERSION) \
@@ -30,6 +42,6 @@ EXE_INC  = \
 LIB_LIBS = \
     -lfiniteVolume \
     -lmeshTools \
-    -ldynamicFvMesh \
-    -lfvOptions \
+    $(DYN_LIBS) \
+    $(FVOPT_LIBS) \
     $(EOF_LIBS)


### PR DESCRIPTION
The library fvOptions is no longer used in OpenFOAM 9 and 10. Additionally, dynamicFvMesh library is no longer used in OpenFOAM 10.