### PR TITLE
Added OpenFOAM-11 compatibility

### DIFF
--- a/libs/coupleElmer/Elmer.H
+++ b/libs/coupleElmer/Elmer.H
@@ -47,7 +47,15 @@ Original Date: 12.12.2016.
 #define FatalErrorInFunction FatalErrorIn(FUNCTION_NAME)
 #endif
 
+#if (FOAM_MAJOR_VERSION == v1812 || FOAM_MAJOR_VERSION < 11)
 #include "fvCFD.H"
+#else
+#include "fvMesh.H"
+#ifndef namespaceFoam
+#define namespaceFoam
+    using namespace Foam;
+#endif
+#endif
 #include "PstreamGlobals.H"
 
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //

--- a/libs/coupleElmer/Make/options
+++ b/libs/coupleElmer/Make/options
@@ -2,6 +2,7 @@ sinclude $(GENERAL_RULES)/mplib$(WM_MPLIB)
 sinclude $(RULES)/mplib$(WM_MPLIB)
 
 FOAM_MAJOR_VERSION=$(firstword $(subst ., ,$(WM_PROJECT_VERSION)))
+PFLAGS_ALL = $(PFLAGS) $(PINC) -std=gnu++0x
 
 ifeq ($(FOAM_MAJOR_VERSION),v1812)
     $(info ************  OF version v1812 ************)
@@ -28,13 +29,17 @@ else
         DYN_INC = -I$(LIB_SRC)/dynamicFvMesh/lnInclude
         DYN_LIBS = -ldynamicFvMesh
     endif
+    ifeq ($(shell test $(FOAM_MAJOR_VERSION) -ge 11; echo $$?),0)
+        $(info ************  OF version >=11 ************)
+        PFLAGS_ALL = $(PFLAGS) $(PINC)
+    endif
 endif
 
 EXE_INC  = \
     -I$(LIB_SRC)/finiteVolume/lnInclude \
     $(DYN_INC) \
     -I$(LIB_SRC)/meshTools/lnInclude \
-    $(PFLAGS) $(PINC) -std=gnu++0x \
+    $(PFLAGS_ALL)\
     -DFOAM_MAJOR_VERSION=$(FOAM_MAJOR_VERSION) \
     -Wno-old-style-cast \
     $(EOF_INC)


### PR DESCRIPTION
1) Header fvCFD.H is no longer defined in OF11. The bare minimum to compile EOF-Library is to include fvMesh.H instead.
2) OF11 uses c++14 standard, so the flag -std=gnu++0x cannot be used. I did not specify here that c++14 standard is required though. Should I add  -std=gnu++1y in the if statement for OF11?