### PR TITLE
optionally continue with elements not found

### DIFF
--- a/libs/OpenFOAM2Elmer.F90
+++ b/libs/OpenFOAM2Elmer.F90
@@ -154,7 +154,7 @@ SUBROUTINE OpenFOAM2ElmerSolver( Model,Solver,dt,TransientSimulation )
   INTEGER, POINTER :: Blist(:)
 
   TYPE(Mesh_t), POINTER :: Mesh
-  LOGICAL :: Visited = .FALSE., UserDefinedCoordinates
+  LOGICAL :: Visited = .FALSE., UserDefinedCoordinates, ContinueOnElementsNotFound
 
   SAVE Visited, Mesh
   
@@ -169,6 +169,9 @@ SUBROUTINE OpenFOAM2ElmerSolver( Model,Solver,dt,TransientSimulation )
   Mesh => GetMesh()
 
   IF(.NOT. Visited ) THEN
+    ContinueOnElementsNotFound = ListGetLogical( Params,'Continue On Elements Not Found',Found)
+        IF ( .NOT. Found ) ContinueOnElementsNotFound = .FALSE.
+
     nVars = 0
     DO i=1,100
       VarName = ListGetString( Params, 'Target Variable '//TRIM(I2S(i)), Found )
@@ -422,8 +425,13 @@ SUBROUTINE OpenFOAM2ElmerSolver( Model,Solver,dt,TransientSimulation )
     END DO ! nBodiesToComm
 
     IF (totElementsFound < nElements) THEN
-      CALL Fatal('OpenFOAM2ElmerSolver','Elmer #'//TRIM(I2S(myLocalRank))//' has ' &
-                 //TRIM(I2S(nElements))//' elements, OpenFOAM found '//TRIM(I2S(totElementsFound)))
+      IF (ContinueOnElementsNotFound) THEN
+        CALL Info('OpenFOAM2ElmerSolver','Elmer #'//TRIM(I2S(myLocalRank))//' has ' &
+                  //TRIM(I2S(nElements))//' elements, OpenFOAM found '//TRIM(I2S(totElementsFound)), Level=3 )
+      ELSE
+        CALL Fatal('OpenFOAM2ElmerSolver','Elmer #'//TRIM(I2S(myLocalRank))//' has ' &
+                  //TRIM(I2S(nElements))//' elements, OpenFOAM found '//TRIM(I2S(totElementsFound)))
+      END IF
     END IF
 
   END IF ! Visited

--- a/libs/coupleElmer/Elmer.C
+++ b/libs/coupleElmer/Elmer.C
@@ -52,6 +52,11 @@ myBoundBox(mesh.points(),false)
     if(init) initialize();
 }
 
+template <class meshT>
+void Foam::Elmer<meshT>::setContinueOnElementsNotFound(bool continueOn)
+{
+    continueOnElementsNotFound_ = continueOn;
+}
 
 template <class meshT>
 void Foam::Elmer<meshT>::initialize()
@@ -148,8 +153,14 @@ void Foam::Elmer<meshT>::initialize()
         }
 
         if (totCellsFound < nCells) {
+            if (continueOnElementsNotFound_) {
+                WarningInFunction << "OpenFOAM #" << myLocalRank << " has " << nCells
+                                 << " cells, Elmer found " << totCellsFound << endl;
+            }
+            else {
             FatalErrorInFunction << "OpenFOAM #" << myLocalRank << " has " << nCells
-                                 << " cells, Elmer found " << totCellsFound << Foam::abort(FatalError); 
+                                 << " cells, Elmer found " << totCellsFound << Foam::abort(FatalError);
+            }
         }
 
         for ( i=0; i<totElmerRanks; i++ ) {

--- a/libs/coupleElmer/Elmer.H
+++ b/libs/coupleElmer/Elmer.H
@@ -81,6 +81,9 @@ public:
         //- Initialize
         void initialize();
 
+        //- Set whether to continue if not all elements are found
+        void setContinueOnElementsNotFound(bool continueOn);
+
         //- Send interpolated scalar field at element centres to Elmer
         void sendScalar(volScalarField& field);
 
@@ -149,6 +152,9 @@ private:
 
         //- Multiregion OF mesh
         bool multiregion_;
+
+        //- Default = call fatal error if not all elements are found
+        bool continueOnElementsNotFound_ = false;
 
         //- Number of cells for this OpenFOAM MPI rank
         int nCells;


### PR DESCRIPTION
In certain cases there can be mismatch between Elmer and OpenFOAM geometries. For example, fluid container is much larger than region with electromagnetic interactions. Or the mismatch can come from geometry optimization on the receiving or sending side, where influence is not important, for exam (e.g., corners of surrounding air in two-phase flow).

In such cases it would be convenient if error on "elements not found" could be disabled. This patch implements ability to optionally disable raising error, when elements by either side (Elmer or OpenFOAM) are not found.
On OpenFOAM side user can set this before initialization, where new Elmer instance is defined w/o initialization
Elmer<fvMesh> receiving(mesh,
-1 //receive
, 0 // w/o initialization
);
receiving.setContinueOnElementsNotFound(true);
receiving.initialize();

On Elmer side in solver "OpenFOAM2Elmer" a flag can be set:
Continue On Elements Not Found = Logical True